### PR TITLE
CI: Correctly install the toolchain and add formatter

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,10 +14,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set rustup version
+      - name: Install the toolchain
         run: |
-          rustup override set nightly
-          rustup component add rust-src --toolchain nightly-2021-07-06-x86_64-unknown-linux-gnu
+          rustup install nightly-2021-07-06-x86_64-unknown-linux-gnu
+          rustup override set nightly-2021-07-06-x86_64-unknown-linux-gnu
+      - name: Add rust-src
+        run: rustup component add rust-src --toolchain nightly-2021-07-06-x86_64-unknown-linux-gnu
       - name: Build
         run: |
           cargo build --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,10 +24,15 @@ jobs:
         run: |
           cargo build --verbose
 
-  lint:
+  format:
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v2
-      - name: Check formatting
-        run: bash meta/format-check.sh
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          components: rustfmt
+          override: true
+      - uses: mbrobbel/rustfmt-check@master
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request removes the `lint` job (fb4926c) and adds the formatting job instead. This automatically formats the code instead of just telling you to do it yourself.
It also correctly installs the toolchain now.